### PR TITLE
Fix: NoSuchFileException when running the project

### DIFF
--- a/src/main/java/de/tjorven/svgscaler/SvgScalerMain.java
+++ b/src/main/java/de/tjorven/svgscaler/SvgScalerMain.java
@@ -23,6 +23,14 @@ public class SvgScalerMain {
     public static void main(String[] args) throws IOException {
         // Verzeichnisse sicherstellen
         File inputDir = new File("svgs/original/");
+        if (!inputDir.exists()) {
+            inputDir.mkdirs();
+
+            System.out.println("Input directory does not exist. Please place SVG files in 'svgs/original/' directory.");
+
+            return;
+        }
+
         File outputDir = new File("svgs/processed/");
         if (!outputDir.exists()) {
             outputDir.mkdirs();


### PR DESCRIPTION
This pull request introduces a small but important change to improve the user experience when running the application. It ensures that the input directory is created if it does not exist and provides a clear message to the user about where to place SVG files.

* [`src/main/java/de/tjorven/svgscaler/SvgScalerMain.java`](diffhunk://#diff-cd01ecc6161d45b1ce743d3c1cbb7b58cea598dd006566a9ccdd3c3238fdb765R26-R33): Added a check to verify the existence of the input directory (`svgs/original/`). If it does not exist, the directory is created, a message is printed to inform the user, and the program exits early.